### PR TITLE
Bump source image to 2.89.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudbees/cje-mm:2.73.3.1
+FROM cloudbees/cje-mm:2.89.3.1
 
 LABEL maintainer "kmadel@cloudbees.com"
 


### PR DESCRIPTION
Which introduces the switch to the alpine based image.

Tested it and all the shell scripts works. The image already includes unzip + curl.

Let me know if you think we should add explicit installation of the necessary command line tools inside the Docker image in case the upstream image changes.